### PR TITLE
[MartinX3/lineage-17.1] untracked_devices.xml: Exclude device/google/atv from removed projects

### DIFF
--- a/untracked_devices.xml
+++ b/untracked_devices.xml
@@ -19,7 +19,7 @@
     <remove-project name="device/generic/uml" />
     <remove-project name="device/generic/x86" />
     <remove-project name="device/generic/x86_64" />
-    <remove-project name="device/google/atv" />
+    <!--<remove-project name="device/google/atv" />--><!--Not existing in LineageOS-->
     <!--<remove-project name="device/google/bonito" />--><!--Not existing in LineageOS-->
     <!--<remove-project name="device/google/bonito-kernel" />--><!--Not existing in LineageOS-->
     <!--<remove-project name="device/google/bonito-sepolicy" />--><!--Not existing in LineageOS-->


### PR DESCRIPTION
This non-existing project now breaks the `repo sync` - it already has been fixed over on `git://github.com/LineageOS/android.git -b lineage-17.1`